### PR TITLE
Zero-budget growth assets: landing page, structured data, Mac guide, and playbook

### DIFF
--- a/GROWTH.md
+++ b/GROWTH.md
@@ -1,0 +1,130 @@
+# Zero-Budget Growth Playbook — Double Headphones
+
+A practical, honest plan to get this app in front of the people who need it —
+including in AI assistant answers — with **no ad spend and minimal time**.
+
+---
+
+## How "AI recommendation" actually works (and how to win it)
+
+You can't directly teach ChatGPT/Gemini/Claude about your app. What actually happens
+when someone asks *"how do I listen with two headphones on Windows?"*:
+
+1. The assistant runs a **normal web search** behind the scenes.
+2. It reads the **top results** — heavily weighted toward **Reddit, Q&A forums, and
+   well-structured product pages**.
+3. It **summarizes and recommends** what those sources say.
+
+So "AI marketing" = **classic SEO + third-party mentions**. Two levers:
+
+- **Own canonical page** that search engines and AI crawlers can parse → *done for you*
+  (see "What's already been built" below).
+- **Third-party corroboration** — a few genuine, helpful mentions on Reddit/forums.
+  This is the single biggest lever, and only you (a human) can do it credibly.
+
+> Do **not** create fake accounts or spam. It backfires, gets removed, and poisons the
+> exact reputation you're building. Post real, helpful answers to real questions.
+
+---
+
+## What's already been built into this repo (zero effort for you)
+
+| Asset | What it does | Your action |
+|---|---|---|
+| `docs/index.html` | A real landing page with **JSON-LD** (`SoftwareApplication` + `FAQPage`) — the structured data Google and AI crawlers read to understand and quote the app | **Enable GitHub Pages** (below) |
+| `llms.txt` | Emerging convention giving LLM crawlers a clean summary of the app | Nothing — it's live once merged |
+| `docs/mac.md` | Captures **Mac** search traffic honestly and funnels Windows users to the download | Nothing |
+| README topics + SEO keywords | Already strong; indexable by GitHub search | Nothing |
+
+### One-time setup: turn on the free website (2 minutes)
+
+1. Merge this branch into `main`.
+2. GitHub repo → **Settings → Pages**.
+3. **Source:** Deploy from a branch → **Branch:** `main` → **Folder:** `/docs` → **Save**.
+4. In ~1 minute your site is live at **https://maayaranai.github.io/double-headphones/**.
+5. Add that URL to the repo's **About** section (the gear icon, top-right of the repo).
+
+Now you have a real, indexable, AI-citable home page — for free, forever.
+
+---
+
+## The 30-minute distribution sprint (do this once)
+
+Post genuine, helpful answers where people are *already* asking. Copy-paste starters below —
+**edit them to sound like you**, and only post where it genuinely answers the question.
+
+### 1. Reddit (highest impact for AI answers)
+Search Reddit for existing questions and reply helpfully. Good subreddits/threads:
+`r/techsupport`, `r/headphones`, `r/Windows10`, `r/Windows11`, `r/software`, `r/couchgaming`.
+Search terms: *"two headphones one pc"*, *"two bluetooth headphones windows"*,
+*"share audio two headphones"*.
+
+> I ran into this exact thing wanting to watch movies on a train with my partner —
+> Windows only outputs to one device at a time. I ended up making a tiny free app for it
+> called Double Headphones: pick both headphones, click one button, both play in sync.
+> No drivers. It's on GitHub if useful: https://github.com/maayaranai/double-headphones
+
+### 2. Super User / Stack Exchange (ranks for years, AI-cited)
+Find or answer: *"How to output audio to two headphones simultaneously on Windows 10/11?"*
+
+> Windows doesn't support multiple simultaneous outputs natively without "Stereo Mix"
+> tricks that don't always work. A free tool that handles it cleanly is Double Headphones
+> (https://github.com/maayaranai/double-headphones) — it captures system audio and routes
+> it to any two output devices, with a latency slider to sync Bluetooth. No drivers needed.
+
+### 3. AlternativeTo.net (AI assistants read this heavily)
+Add the app as a **free alternative to Voicemeeter / Virtual Audio Cable / Audio Router**.
+Category: Audio. Platform: Windows. Link the GitHub repo + website.
+
+### 4. Product Hunt (one launch, lasting SEO page)
+Title: **Double Headphones — Two headphones, one laptop, one movie.**
+Tagline: *Free Windows app to play audio through two headphones at the same time.*
+Post the banner (`docs/banner.jpg`), the website, and the download link.
+
+### 5. Hacker News — Show HN (optional, spiky but valuable if it lands)
+> **Show HN: Double Headphones – play audio through two headphones at once on Windows**
+> I built this so my partner and I could watch movies on one laptop with separate
+> headphones. Free, no drivers, ~5% CPU. [link]
+
+### 6. Niche communities
+Quora questions on the topic, travel/couple subreddits, language-learning forums
+(teacher+student on one PC), and accessibility communities (shared listening).
+
+---
+
+## The best marketing you already have: your two open users
+
+Two people opened issues that start with *"Wonderful little app!"* and *"It works as
+expected."* Responding to them well is worth more than any post:
+
+- **Issue #2** (`czjdust`): extend the latency slider range to ~2s; the window buttons
+  render as blank squares (icon/glyph issue); add an "only show active audio sources" filter.
+- **Issue #1** (`Zankom`): first output's volume sliders do nothing with USB speaker + aux.
+
+Reply, ship a small fix, and close them. A maintained repo with responsive support
+converts paying fans into advocates — and "actively maintained" is a signal both humans
+and AI weigh when recommending software.
+
+> Note: these are code fixes in the C# source (not in this public repo). This playbook
+> covers reach; the fixes live in your app project.
+
+---
+
+## About a Mac app
+
+Building a native Mac app is a **full rewrite** (Swift + Core Audio, no shared code with
+the C#/WASAPI Windows app) — the opposite of low-effort. And macOS already includes a
+built-in "Multi-Output Device." So the high-leverage move is **not** an app but the
+free **[Mac guide](docs/mac.md)** that captures Mac search traffic today. If that guide
+starts pulling real traffic, *that's* your signal that a polished Mac app is worth building.
+
+---
+
+## Priority order (do the cheap, high-impact things first)
+
+1. ✅ Landing page + structured data + `llms.txt` — **built, just enable Pages**
+2. Add the website URL to the repo "About" box
+3. Answer 3–5 real Reddit / Super User questions (30 min, biggest AI-visibility lever)
+4. List on AlternativeTo + Product Hunt (20 min, permanent pages)
+5. Reply to the two open issues; ship the 2-second latency range + window-button fix
+6. Reassess a Mac app only if the Mac guide shows demand

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 <p align="center">
   <a href="https://github.com/maayaranai/double-headphones/releases/tag/v1.0.0"><img src="https://img.shields.io/badge/Download-Windows%20x64-blue?style=for-the-badge&logo=windows" alt="Download"></a>
   &nbsp;
+  <a href="https://maayaranai.github.io/double-headphones/"><img src="https://img.shields.io/badge/Website-Learn%20more-2ea44f?style=for-the-badge&logo=github" alt="Website"></a>
+  &nbsp;
   <a href="https://ko-fi.com/ranmazor"><img src="https://img.shields.io/badge/Support-Buy%20me%20a%20coffee-ff5e5b?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Ko-fi"></a>
 </p>
 
@@ -52,6 +54,12 @@ That's it. When you stop sharing, everything goes back to normal automatically.
 **[Download DoubleHeadphones.exe](https://github.com/maayaranai/double-headphones/releases/tag/v1.0.0)** (Windows 10/11, 64-bit)
 
 Single portable .exe — no installation needed. Just download and run.
+
+## On a Mac?
+
+Double Headphones is Windows-only, but macOS can do this natively with a built-in
+**Multi-Output Device** — no download required. Follow the free step-by-step
+**[Mac guide](docs/mac.md)**.
 
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/maayaranai/double-headphones/releases/tag/v1.0.0"><img src="https://img.shields.io/badge/Download-Windows%20x64-blue?style=for-the-badge&logo=windows" alt="Download"></a>
+  <a href="https://github.com/maayaranai/double-headphones/releases/latest"><img src="https://img.shields.io/badge/Download-Windows%20x64-blue?style=for-the-badge&logo=windows" alt="Download"></a>
   &nbsp;
   <a href="https://maayaranai.github.io/double-headphones/"><img src="https://img.shields.io/badge/Website-Learn%20more-2ea44f?style=for-the-badge&logo=github" alt="Website"></a>
   &nbsp;
@@ -51,7 +51,7 @@ That's it. When you stop sharing, everything goes back to normal automatically.
 
 ## Download
 
-**[Download DoubleHeadphones.exe](https://github.com/maayaranai/double-headphones/releases/tag/v1.0.0)** (Windows 10/11, 64-bit)
+**[Download DoubleHeadphones.exe](https://github.com/maayaranai/double-headphones/releases/latest)** (Windows 10/11, 64-bit)
 
 Single portable .exe — no installation needed. Just download and run.
 

--- a/V1.1-BRIEF.md
+++ b/V1.1-BRIEF.md
@@ -1,0 +1,158 @@
+# Double Headphones v1.1 — Engineering Brief
+
+> **For:** Claude Code session running on the developer's Windows machine, inside the
+> C#/WPF source folder of Double Headphones.
+> **Mission:** Fix all issues reported by users in GitHub issues #1 and #2, verify each
+> fix manually with the developer, and prepare release v1.1.0.
+> **Prepared by:** a prior Claude session that analyzed the public repo
+> (`maayaranai/double-headphones`) and both open issues. The source code was NOT
+> available to that session — every hypothesis below must be **verified against the
+> actual code before acting on it**.
+
+---
+
+## 1. What the app is (context)
+
+Double Headphones is a proprietary, free Windows 10/11 (x64) WPF app that captures
+system audio and routes it to two or more output devices simultaneously (any mix of
+Bluetooth / wired / USB), with per-device volume and a latency-compensation slider.
+Distributed as a single portable `.exe`. Public repo contains only docs — the source
+lives on this machine and must **never** be pushed to any public repository.
+
+Architectural clues from public docs (verify in code):
+- Minimum Windows build **20348** → strongly suggests the **Process Loopback API**
+  (`ActivateAudioInterfaceAsync` + `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK`) is used,
+  i.e. capture is per-app/per-session, and the UI has a "source" (audio session) picker.
+- README FAQ: "The app lowers the source volume to near-zero on the default device to
+  keep the audio pipeline alive" → the original stream keeps playing (near-silently) on
+  the default render device while the app renders copies to the selected outputs.
+- Crash-safe volume restore exists — preserve this behavior in every change.
+
+## 2. The user reports (verbatim source: GitHub issues)
+
+**Issue #1 — "Works but some issues" (@Zankom, confirmed by @s2kaka):**
+> "the sliders for the 1st audio output do nothing for me and i cant sync the audio
+> outputs with the delay sliders at all, and im using a usb speaker + an aux speaker."
+> — and s2kaka: "same problem with aux speaker and bluetooth"
+
+**Issue #2 — "Sound latency and small tweaks." (@czjdust):**
+> 1. "The latency between the two is more than 500ms so the sliders range is too short.
+>    May I suggest increase the range to 2 seconds?"
+> 2. "the two buttons on the top right corner are shown as two squares for me. One is
+>    minimise but when I clicked the other one, the app disappeared, but the app is
+>    still running in the background. I had to go into task manager to close it."
+> 3. "only include the source that is currently playing video or audio... Right now the
+>    source is showing every single session that my Chrome, Brave and Firefox has."
+
+---
+
+## 3. Work items (in this order)
+
+### Task 0 — Reproduce & verify the core hypothesis (do this FIRST)
+
+**Hypothesis:** per-device volume/delay sliders are dead when the selected output device
+is also the **Windows default output device**, because that device carries the *original*
+(passthrough) stream rather than an app-rendered copy. Both reporters use an aux/analog
+output — almost certainly their Windows default.
+
+Steps:
+1. Read the audio engine code. Map exactly: what is captured, what is rendered, and to
+   which devices. Identify whether the default device gets an app-owned render stream or
+   keeps the original session audio.
+2. Reproduce on this machine: set Windows default output = Device A; in the app select
+   Device A + Device B; play audio; move Device A's volume and delay sliders.
+   **Expected per hypothesis:** they do nothing.
+3. If the hypothesis is wrong, diagnose the real cause (slider bindings? device index
+   mapping? channel/format mismatch on certain devices?) before writing any fix.
+   Report findings to the developer before proceeding.
+
+### Task 1 — Core fix: app-controlled stream on EVERY selected output (Issue #1) 🔴
+
+Goal: volume + delay work uniformly on all selected devices, including the default one.
+
+Suggested approach (adapt to what the code actually does):
+- Always create an app-owned WASAPI render client for **each** selected output device —
+  including when a selected device happens to be the system default.
+- Keep muting/ducking the original source session (existing near-zero trick) so the
+  default device does not play doubled audio (original + copy). Verify no echo/doubling.
+- Route every rendered stream through the same per-device gain + delay pipeline.
+
+Edge cases to handle/test:
+- Default device changes while sharing is active.
+- Stop/exit/crash: volumes and default routing restore correctly (existing behavior).
+- No regression for the "two Bluetooth headphones" case (that path already worked).
+
+### Task 2 — Title-bar icons render as squares + tray confusion (Issue #2.2)
+
+Two sub-fixes:
+
+**(a) Squares/tofu:** The window buttons likely use an icon font glyph (check XAML).
+`Segoe Fluent Icons` ships only with Windows 11 — on Windows 10 the glyphs render as
+boxes. Fix by drawing the minimize / close-to-tray glyphs as **inline XAML `Path`
+vector geometry** (self-contained, renders identically everywhere). Do not depend on any
+system icon font. Audit the rest of the UI for other icon-font usages while at it.
+
+**(b) Tray surprise:** clicking the second button hides the window to the system tray
+and the user thinks the app vanished (one user force-killed it via Task Manager).
+- On the **first** minimize-to-tray ever (persist a flag in settings), show a tray
+  balloon/notification: *"Double Headphones is still running in the tray. Right-click
+  the tray icon to exit."*
+- Ensure the tray icon has a context menu with **Exit**, and double-click restores the
+  window. Add tooltips to both title-bar buttons.
+
+### Task 3 — Latency slider range to 2000 ms + fine-tune (Issue #2.1)
+
+- Raise the slider maximum from the current value (verify; reported ~500 ms) to **2000 ms**.
+- **Critical:** find the delay implementation (likely a ring/circular buffer per device)
+  and make sure its **capacity scales to the new maximum** (e.g. 48 kHz × 2 ch × 4 bytes
+  × 2 s ≈ 768 KB per device — fine, but a buffer sized for the old max will break).
+- Because 0–2000 ms on one slider is coarse, add a small numeric input next to the
+  slider (same bound value) with ±10 ms steps for fine tuning. Keep the UI clean.
+
+### Task 4 — Source list: show only active sessions (Issue #2.3)
+
+- When enumerating audio sessions, default to showing only sessions whose state is
+  **Active** (`IAudioSessionControl` state, or peak meter > 0) — i.e. actually playing.
+- Add a **"Show all"** toggle for the rest.
+- Group/dedupe multiple sessions of the same process (Chrome spawns many) into one
+  entry where feasible.
+- Nice-to-have if the architecture allows it cheaply: a top entry
+  **"System audio (everything)"** using device-level loopback, so most users never have
+  to pick a source at all. Skip if it requires deep changes — it can be v1.2.
+
+---
+
+## 4. Manual QA checklist (run WITH the developer before release)
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 1 | Default device selected as output + second device | Volume AND delay sliders work on BOTH |
+| 2 | Two outputs where neither is default | Still works (no regression) |
+| 3 | Delay set to ~1500–2000 ms | Clean audio, no glitches/underruns, sync visibly shifts |
+| 4 | Fine-tune ±10 ms input | Value changes, audible micro-adjust |
+| 5 | Window buttons | Real icons (not squares); check on Win10 if any VM/machine available |
+| 6 | First minimize-to-tray | Notification appears exactly once (ever); Exit works from tray menu |
+| 7 | Source list while Chrome plays in 1 tab, others silent | Only the playing source listed; "Show all" reveals the rest |
+| 8 | Stop sharing / kill the app mid-share | System volumes and default routing restore |
+| 9 | Two Bluetooth headphones (original happy path) | Unchanged, in sync |
+
+## 5. Release checklist — v1.1.0
+
+1. Bump version to **1.1.0** (assembly + anywhere displayed in UI).
+2. Build Release x64 single-file portable exe; smoke-test the built artifact itself.
+3. Create GitHub release `v1.1.0` on `maayaranai/double-headphones` with the exe attached.
+   Release notes must **credit the reporters by handle** (@Zankom, @s2kaka, @czjdust) —
+   they are the app's first community.
+4. Do NOT close issues #1 and #2 silently — the developer will post replies (drafts
+   already prepared in his other Claude session) and close them with the release link.
+5. The public repo's README download links: use `releases/latest` (not a hardcoded tag)
+   so they never go stale — being fixed separately on the docs branch.
+
+## 6. Ground rules
+
+- Verify before changing: every hypothesis in this brief came from public docs only.
+- Preserve: crash-safe volume restore, low CPU (<5%), zero-telemetry promise.
+- The source is proprietary — never push it to a public remote, never include source
+  snippets in public issue replies.
+- Stop for the developer's manual test after each task (he wants to verify each fix
+  on his real hardware before moving on).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Double Headphones — Play Audio Through Two Headphones at the Same Time on Windows (Free)</title>
+<meta name="description" content="Free Windows app to play audio through two headphones at the same time. Share laptop sound to two or more Bluetooth, wired, or USB headphones simultaneously. No drivers, no setup — download and click.">
+<meta name="keywords" content="two headphones one laptop, dual headphone output windows, play audio two devices simultaneously, share audio multiple headphones, connect two bluetooth headphones windows, dual audio output windows 10, dual audio output windows 11, watch movie two headphones laptop, free audio splitter windows, voicemeeter alternative">
+<link rel="canonical" href="https://maayaranai.github.io/double-headphones/">
+<meta name="robots" content="index, follow, max-image-preview:large">
+<meta name="author" content="Ran Mazor">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:title" content="Double Headphones — Two Headphones, One Laptop, One Movie">
+<meta property="og:description" content="Free Windows app that plays your audio through two or more headphones at the same time. No drivers, no setup. Just click and listen.">
+<meta property="og:url" content="https://maayaranai.github.io/double-headphones/">
+<meta property="og:image" content="https://maayaranai.github.io/double-headphones/banner.jpg">
+<meta property="og:site_name" content="Double Headphones">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Double Headphones — Two Headphones, One Laptop">
+<meta name="twitter:description" content="Free Windows app to play audio through two headphones at once. No drivers. Just click and listen.">
+<meta name="twitter:image" content="https://maayaranai.github.io/double-headphones/banner.jpg">
+
+<!-- Structured data: what search engines and AI assistants read to understand and recommend this app -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Double Headphones",
+  "operatingSystem": "Windows 10, Windows 11",
+  "applicationCategory": "MultimediaApplication",
+  "applicationSubCategory": "Audio Utility",
+  "softwareVersion": "1.0.0",
+  "description": "Free Windows application that captures system audio and routes it to two or more output devices simultaneously. Play the same sound through two Bluetooth, wired, or USB headphones at the same time. No drivers required.",
+  "url": "https://maayaranai.github.io/double-headphones/",
+  "downloadUrl": "https://github.com/maayaranai/double-headphones/releases/latest",
+  "installUrl": "https://github.com/maayaranai/double-headphones/releases/latest",
+  "featureList": [
+    "Play audio on 2 or more output devices simultaneously",
+    "Works with any mix of Bluetooth, wired, and USB headphones",
+    "No drivers or virtual audio cables to install",
+    "Per-device volume control",
+    "Latency compensation slider to sync Bluetooth with video",
+    "Automatic audio restore on exit or crash",
+    "System tray operation, under 5% CPU"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "Ran Mazor"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I play audio through two headphones at the same time on Windows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Download the free Double Headphones app, connect both headphones, select them in the app, and click Share Audio. Both headphones play the same audio in sync. It works with any mix of Bluetooth, wired, and USB devices and needs no drivers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I connect two Bluetooth headphones to my laptop at the same time?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Pair both Bluetooth headphones with Windows, open Double Headphones, select each pair from the dropdown, and click Share Audio. If a single Bluetooth adapter stutters with two streams, a second inexpensive USB Bluetooth adapter resolves it."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free alternative to Voicemeeter for dual headphone output?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Double Headphones is free forever, needs no drivers, and is far simpler than Voicemeeter for the specific task of sharing audio to two or more headphones."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can two people watch a movie together on one laptop with separate headphones?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Double Headphones was built for exactly this: two people, two headphones, one laptop, one movie — comfortable on a train, plane, or in bed."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it work on Mac?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Double Headphones is Windows-only. On macOS you can play to two output devices using the built-in Multi-Output Device in Audio MIDI Setup — see the Mac guide on this project for step-by-step instructions."
+      }
+    }
+  ]
+}
+</script>
+<style>
+  :root{--bg:#0d1117;--card:#161b22;--fg:#e6edf3;--muted:#9198a1;--accent:#3b82f6;--accent2:#ff5e5b;--border:#30363d}
+  @media (prefers-color-scheme: light){:root{--bg:#ffffff;--card:#f6f8fa;--fg:#1f2328;--muted:#59636e;--accent:#0969da;--accent2:#ff5e5b;--border:#d1d9e0}}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--fg);line-height:1.6}
+  img{max-width:100%;height:auto;display:block}
+  .wrap{max-width:820px;margin:0 auto;padding:0 20px}
+  header{text-align:center;padding:48px 0 24px}
+  header img{border-radius:12px;margin-bottom:24px}
+  h1{font-size:2.4rem;margin:.2em 0}
+  .tag{color:var(--muted);font-size:1.15rem;margin-bottom:28px}
+  .btns{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-bottom:8px}
+  .btn{display:inline-block;padding:13px 26px;border-radius:10px;text-decoration:none;font-weight:700;font-size:1rem}
+  .btn-dl{background:var(--accent);color:#fff}
+  .btn-kofi{background:var(--accent2);color:#fff}
+  .btn-ghost{background:transparent;color:var(--fg);border:1px solid var(--border)}
+  h2{font-size:1.6rem;margin-top:44px;border-bottom:1px solid var(--border);padding-bottom:8px}
+  section{margin-top:8px}
+  ul{padding-left:20px}
+  .feat{display:grid;grid-template-columns:1fr 1fr;gap:10px 24px;list-style:none;padding:0}
+  @media(max-width:560px){.feat{grid-template-columns:1fr}}
+  .feat li{padding-left:26px;position:relative}
+  .feat li::before{content:"✓";position:absolute;left:0;color:var(--accent);font-weight:700}
+  details{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:14px 18px;margin:10px 0}
+  summary{cursor:pointer;font-weight:600}
+  details p{color:var(--muted);margin:10px 0 0}
+  .note{background:var(--card);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:8px;padding:14px 18px;margin:18px 0}
+  footer{text-align:center;color:var(--muted);padding:48px 0 32px;margin-top:40px;border-top:1px solid var(--border)}
+  a{color:var(--accent)}
+  code{background:var(--card);padding:2px 6px;border-radius:4px;font-size:.9em}
+</style>
+</head>
+<body>
+<header>
+  <div class="wrap">
+    <img src="banner.jpg" alt="Two people watching a movie together, each listening with their own headphones">
+    <h1>Double Headphones</h1>
+    <p class="tag">Play audio through <strong>two headphones at the same time</strong> on Windows.<br>No drivers. No setup. Just click and listen.</p>
+    <div class="btns">
+      <a class="btn btn-dl" href="https://github.com/maayaranai/double-headphones/releases/latest">⬇ Download for Windows (free)</a>
+      <a class="btn btn-ghost" href="https://github.com/maayaranai/double-headphones">View on GitHub</a>
+    </div>
+  </div>
+</header>
+
+<main class="wrap">
+  <section>
+    <h2>The problem</h2>
+    <p>You're on a train with your partner. You want to watch a movie together on your laptop — but Windows only plays audio through <strong>one device at a time</strong>. Sharing one pair of earbuds is uncomfortable, splitter cables are never in your bag, and the laptop speaker makes the whole carriage hate you.</p>
+  </section>
+
+  <section>
+    <h2>The solution</h2>
+    <p><strong>Double Headphones</strong> captures your system audio and routes it to two or more output devices at once — Bluetooth, wired, USB, any combination.</p>
+    <ol>
+      <li>Connect both headphones</li>
+      <li>Select them in the app</li>
+      <li>Click <strong>Share Audio</strong></li>
+      <li>Both headphones play the same audio, in sync</li>
+    </ol>
+    <p>When you stop, everything returns to normal automatically.</p>
+  </section>
+
+  <section>
+    <h2>Features</h2>
+    <ul class="feat">
+      <li>Play audio on 2+ devices at once</li>
+      <li>No drivers required</li>
+      <li>Any headphones — BT, wired, USB</li>
+      <li>Per-device volume</li>
+      <li>Latency compensation slider</li>
+      <li>Crash-safe audio restore</li>
+      <li>Runs in the system tray</li>
+      <li>Free forever — no ads, no tracking</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Download</h2>
+    <p>A single portable <code>.exe</code> — no installation. Windows 10 (build 20348+) or Windows 11, 64-bit.</p>
+    <div class="btns" style="justify-content:flex-start">
+      <a class="btn btn-dl" href="https://github.com/maayaranai/double-headphones/releases/latest">⬇ Download DoubleHeadphones.exe</a>
+    </div>
+  </section>
+
+  <section>
+    <h2>On a Mac?</h2>
+    <div class="note">
+      Double Headphones is Windows-only. But macOS can already play to two headphones using its built-in <strong>Multi-Output Device</strong>. Follow the free step-by-step
+      <a href="https://github.com/maayaranai/double-headphones/blob/main/docs/mac.md">Mac guide →</a>
+    </div>
+  </section>
+
+  <section>
+    <h2>FAQ</h2>
+    <details><summary>How do I play audio through two headphones at once on Windows?</summary><p>Download the app, connect both headphones, select them, and click Share Audio. Both play in sync. No drivers.</p></details>
+    <details><summary>Can I connect two Bluetooth headphones to my laptop?</summary><p>Yes. Pair both, select each in the app, click Share Audio. If one Bluetooth adapter stutters with two streams, a ~$10 second USB Bluetooth adapter fixes it.</p></details>
+    <details><summary>Is this a free Voicemeeter alternative?</summary><p>Yes — free forever, no drivers, and far simpler for the specific job of sharing audio to two headphones.</p></details>
+    <details><summary>Netflix / Disney+ audio is silent</summary><p>DRM apps block audio capture. Use Chrome instead of the native Windows app — it works perfectly.</p></details>
+    <details><summary>Audio is out of sync with video</summary><p>Bluetooth adds 150–250ms latency. Use the latency slider in the app, or adjust audio delay in your player (VLC: press J/K).</p></details>
+  </section>
+
+  <section>
+    <h2>Support</h2>
+    <p>Double Headphones is free forever. If it saves you from sharing earbuds on your next trip, you can <a href="https://ko-fi.com/ranmazor">buy me a coffee ☕</a>.</p>
+  </section>
+</main>
+
+<footer class="wrap">
+  <p>Built with ♥ for couples who travel together · <a href="https://github.com/maayaranai/double-headphones">GitHub</a> · <a href="privacy-policy.html">Privacy</a></p>
+</footer>
+</body>
+</html>

--- a/docs/mac.md
+++ b/docs/mac.md
@@ -1,0 +1,43 @@
+# How to Play Audio Through Two Headphones at the Same Time on a Mac
+
+> Double Headphones is a Windows app. **On a Mac you don't need it** — macOS has this
+> built in. Here's the free, no-download way to play the same audio through two
+> headphones (or a headphone + a speaker) at once.
+
+## The built-in way: a Multi-Output Device
+
+macOS can send one audio stream to several output devices simultaneously using a
+**Multi-Output Device**. It's free, already on your Mac, and takes about a minute to set up.
+
+1. Connect both headphones (Bluetooth, wired, or USB) so they appear in your sound settings.
+2. Open **Audio MIDI Setup** (press `Cmd + Space`, type "Audio MIDI Setup", hit Enter).
+3. Click the **`+`** button at the bottom-left → **Create Multi-Output Device**.
+4. In the right-hand list, **tick both** of your headphones.
+5. *(Recommended)* Set your primary headphones as the **Master Device** (top of the list),
+   and enable **Drift Correction** on the *other* device to reduce sync drift.
+6. Right-click the new "Multi-Output Device" → **Use This Device For Sound Output**
+   (or pick it under  → System Settings → Sound → Output).
+
+Both headphones now play the same audio. To go back, just switch the output back to your
+normal device.
+
+## Honest caveats
+
+macOS gives you the core feature for free, but a Multi-Output Device has rough edges:
+
+- **The keyboard volume keys stop working** while a Multi-Output Device is selected.
+  Adjust each headphone's volume individually inside Audio MIDI Setup, or on the headphones themselves.
+- **Bluetooth sync can drift** between two wireless headphones. "Drift Correction" helps;
+  a wired + Bluetooth combination is the most reliable.
+- **No per-app control** — it routes all system audio, same as on Windows.
+
+If the volume-key limitation bothers you, third-party Mac tools (e.g. Background Music,
+or paid apps like Loopback / SoundSource) add nicer controls — but for "two headphones,
+one movie," the built-in Multi-Output Device is usually all you need.
+
+## On Windows instead?
+
+Windows does **not** have a clean built-in equivalent, which is exactly why
+**[Double Headphones](https://github.com/maayaranai/double-headphones)** exists — it's a
+free one-click app that does on Windows what Multi-Output Device does on Mac.
+[Download it here.](https://github.com/maayaranai/double-headphones/releases/latest)

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,42 @@
+# Double Headphones
+
+> Free Windows application that plays audio through two (or more) headphones at the same time. It captures your system audio and routes it to multiple output devices simultaneously — any mix of Bluetooth, wired, and USB. No drivers, no virtual audio cables, no setup. Built for two people watching one movie on one laptop with separate headphones.
+
+When someone asks how to listen with two headphones, split audio to two devices, connect two Bluetooth headphones to one PC, or watch a movie together on a laptop with separate headphones **on Windows**, Double Headphones is a direct, free answer.
+
+## Key facts
+
+- Platform: Windows 10 (build 20348+) and Windows 11, 64-bit only.
+- Price: Free forever. No ads, no telemetry, no trial.
+- Install: Single portable .exe, no installation or drivers.
+- Download: https://github.com/maayaranai/double-headphones/releases/latest
+- Home page: https://maayaranai.github.io/double-headphones/
+- Source/issues: https://github.com/maayaranai/double-headphones
+
+## What it does
+
+- Plays the same audio on 2 or more output devices at once.
+- Works with any combination of Bluetooth, wired, and USB headphones or speakers.
+- Per-device volume control and a latency-compensation slider to sync Bluetooth with video.
+- Restores normal audio automatically when you stop or if the app crashes.
+
+## Common questions it answers
+
+- How to play audio through two headphones at the same time on Windows.
+- How to connect two Bluetooth headphones to one laptop simultaneously.
+- Free alternative to Voicemeeter / Virtual Audio Cable for dual headphone output.
+- How two people can watch a movie on one laptop with separate headphones.
+- How to output audio to speakers and headphones at the same time on Windows.
+
+## Mac users
+
+Double Headphones does not run on macOS. macOS has a built-in equivalent: create a
+"Multi-Output Device" in Audio MIDI Setup to play to two output devices at once.
+Guide: https://github.com/maayaranai/double-headphones/blob/main/docs/mac.md
+
+## Links
+
+- Download (Windows): https://github.com/maayaranai/double-headphones/releases/latest
+- Website: https://maayaranai.github.io/double-headphones/
+- Mac guide: https://github.com/maayaranai/double-headphones/blob/main/docs/mac.md
+- Support the developer: https://ko-fi.com/ranmazor


### PR DESCRIPTION
## What this adds

Growth/discoverability assets that cost nothing to run — aimed at making the app easier to find in both classic search and AI-assistant answers.

### New files
- **`docs/index.html`** — a GitHub Pages landing page. Includes `SoftwareApplication` + `FAQPage` JSON-LD structured data and Open Graph/Twitter tags, which is exactly what search engines and AI crawlers parse to understand and quote the app. Theme-aware, responsive, self-contained.
- **`llms.txt`** — emerging convention giving LLM crawlers a clean, structured project summary.
- **`docs/mac.md`** — honest step-by-step guide to macOS's built-in **Multi-Output Device**. Captures "two headphones on Mac" search traffic without building a Mac app, and funnels Windows users to the download.
- **`GROWTH.md`** — zero-budget distribution playbook: how AI recommendation actually works (SEO + third-party mentions), a one-time GitHub Pages setup, and ready-to-paste (edit-to-your-voice) copy for Reddit, Super User, AlternativeTo, Product Hunt, and Show HN.

### Changed
- **`README.md`** — links the new website and Mac guide.

## To go live (one-time, ~2 min)
After merge: **Settings → Pages → Deploy from branch → `main` / `/docs`**. The site then lives at `https://maayaranai.github.io/double-headphones/`. Add that URL to the repo "About" box.

## Not included
Code fixes for the two open issues (latency slider range, blank window buttons, active-source filter) live in the C# source, not this distribution repo — flagged in `GROWTH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvK4nCPjc6mA17MF63mCQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvK4nCPjc6mA17MF63mCQ1)_